### PR TITLE
Use config for messages instead of hardcoding

### DIFF
--- a/jquery-idleTimeoutSwal.js
+++ b/jquery-idleTimeoutSwal.js
@@ -154,33 +154,33 @@
     //----------- WARNING DIALOG FUNCTIONS --------------//
     openWarningDialog = function () {
 
-		swal({
-		  title: 'Inactivty timeout',
-		  text: "",
-		  type: "warning",
-		  showCancelButton: true,
-		  confirmButtonColor: "#DD6B55",
-		  confirmButtonText: "Refresh my session!",
-		  cancelButtonText: "Log me out",
-		  closeOnConfirm: false,
-		  closeOnCancel: false
-		},
-		function(isConfirm){
-		  if (isConfirm) {
-            stopDialogTimer();
-            startIdleTimer();		  	
-		    swal({
-		      title: "Session refreshed!", 
-		      text: "Your session has been refreshed", 
-		      type: "success",
-		      timer: 3000,
-		   });
+      swal({
+          title: currentConfig.dialogText,
+          text: "",
+          type: "warning",
+          showCancelButton: true,
+          confirmButtonColor: "#DD6B55",
+          confirmButtonText: currentConfig.dialogStayLoggedInButton,
+          cancelButtonText: currentConfig.dialogLogOutNowButton,
+          closeOnConfirm: false,
+          closeOnCancel: false
+        },
+        function(isConfirm){
+          if (isConfirm) {
+                stopDialogTimer();
+                startIdleTimer();
+            swal({
+              title: "Session refreshed!",
+              text: "Your session has been refreshed",
+              type: "success",
+              timer: 3000,
+           });
 
-		  } else {
-			    logoutUser();
-		  }
-		});
-				
+          } else {
+              logoutUser();
+          }
+      });
+
       countdownDisplay();
 
       document.title = currentConfig.dialogTitle;
@@ -217,7 +217,7 @@
     };
 
     destroyWarningDialog = function () {
-    	$("span#dialogText-warning").remove();
+      $("span#dialogText-warning").remove();
 //      $("#idletimer_warning_dialog").dialog('destroy').remove();
       document.title = origTitle;
 
@@ -235,7 +235,7 @@
 //        if (mins < 10) { mins = '0' + mins; }
         secs = dialogDisplaySeconds // - (mins * 60); // seconds
  //       if (secs < 10) { secs = '0' + secs; }
- 		$(".sweet-alert p").html("Session will expire in " + secs + " seconds");
+    $(".sweet-alert p").html("Session will expire in " + secs + " seconds");
 //        $("span#dialogText-warning").html(secs).show();
         dialogDisplaySeconds -= 1;
       }, 1000);

--- a/jquery-idleTimeoutSwal.js
+++ b/jquery-idleTimeoutSwal.js
@@ -52,6 +52,10 @@
       dialogStayLoggedInButton: 'Stay Logged In',
       dialogLogOutNowButton: 'Log Out Now',
 
+      dialogConfirm: true, // set to false for no confirmation alert
+      dialogConfirmTitle: 'Session refreshed!',
+      dialogConfirmText: 'Your session has been refreshed',
+
       // error message if https://github.com/marcuswestin/store.js not enabled
       errorAlertMessage: 'Please disable "Private Mode", or upgrade to a modern browser. Or perhaps a dependent file missing. Please see: https://github.com/marcuswestin/store.js',
 
@@ -162,7 +166,7 @@
           confirmButtonColor: "#DD6B55",
           confirmButtonText: currentConfig.dialogStayLoggedInButton,
           cancelButtonText: currentConfig.dialogLogOutNowButton,
-          closeOnConfirm: false,
+          closeOnConfirm: !currentConfig.dialogConfirm,
           closeOnCancel: false
         },
         function(isConfirm){
@@ -170,8 +174,8 @@
                 stopDialogTimer();
                 startIdleTimer();
             swal({
-              title: "Session refreshed!",
-              text: "Your session has been refreshed",
+              title: defaultConfig.dialogConfirmTitle,
+              text: defaultConfig.dialogConfirmText,
               type: "success",
               timer: 3000,
            });


### PR DESCRIPTION
Hey there!

The impetus for this change was noticing a typo in `title: 'Inactivty timeout',` and trying to figure out where to fix it. Since idleTimeout was already using `defaultConfig` as a vessel for other messaging customization, I just extended those config variables into your sweet alert implementation.

The relevant variables being used now are:

``` js
dialogTitle: 'Session Expiration Warning', // also displays on browser title bar
dialogText: 'Because you have been inactive, your session is about to expire.',
dialogStayLoggedInButton: 'Stay Logged In',
dialogLogOutNowButton: 'Log Out Now',

dialogConfirm: true, // set to false for no confirmation alert
dialogConfirmTitle: 'Session refreshed!',
dialogConfirmText: 'Your session has been refreshed',
```
